### PR TITLE
update joblib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     platforms='any',
     python_requires='>=3.6',
     install_requires=['future', 'h5py', 'click', 'numpy==1.14.5',
-                      'pyhsmm', 'autoregressive', 'joblib==0.11',
+                      'pyhsmm', 'autoregressive', 'joblib==0.13.1',
                       'hdf5storage', 'ruamel.yaml>=0.15.0', 'tqdm'],
     dependency_links=['git+https://github.com/mattjj/pybasicbayes.git@master#egg=pybasicbayes-1',
                       'git+https://github.com/mattjj/pyhsmm-autoregressive.git@master#egg=autoregressive-1'],


### PR DESCRIPTION
Updates joblib to `0.13.1`. I've tested loading in `job_xxx.p` files and my `arhmm.checkpoint` files. Loading models saved with joblib `0.11` works without error.