### PR TITLE
fix(test): added missing h5py context managers

### DIFF
--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -264,8 +264,8 @@ class TestUtils(TestCase):
 
         outpath = 'data/out_scores.h5'
 
-        tmp_h5 = h5py.File(outpath, 'w')
-        dict_to_h5(tmp_h5, data_dict)
+        with h5py.File(outpath, 'w') as tmp_h5:
+            dict_to_h5(tmp_h5, data_dict)
 
         assert os.path.exists(outpath)
         os.remove(outpath)
@@ -283,8 +283,8 @@ class TestUtils(TestCase):
             (1, 2): 'tuple key test'
         }
 
-        tmp_h5 = h5py.File(outpath, 'w')
-        dict_to_h5(tmp_h5, test_dict)
+        with h5py.File(outpath, 'w') as tmp_h5:
+            dict_to_h5(tmp_h5, test_dict)
 
         assert os.path.exists(outpath)
         os.remove(outpath)


### PR DESCRIPTION
## Issue being fixed or feature implemented
`test_dict_to_h5()` was opening h5py files without using a context manager.

## How Has This Been Tested?
Locally and Travis

## What Was Done?
Replaced vanilla h5 file open with context manager

## Breaking Changes
None

## Checklists
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
