### PR TITLE
fix: Updated python version requirement limit to match all other repositories

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     packages=find_packages(exclude='docs'),
     include_package_data=True,
     platforms='any',
-    python_requires='>=3.6',
+    python_requires='>=3.6,<3.8',
     install_requires=['six==1.15.0', 'h5py==2.10.0',
                       'scipy==1.3.2', 'numpy==1.18.3', 'click==7.0', 'cython==0.29.14',
                       'pandas==1.0.5', 'future==0.18.2', 'joblib==0.15.1',


### PR DESCRIPTION
Issue described [here](https://github.com/dattalab/moseq2-app/issues/75).

## Issue being fixed or feature implemented
`moseq2-model` cannot be installed with newer python versions since some of its dependency packages do not exist for them.


## How Has This Been Tested?
Locally and Travis

## What Was Done?
Added a maximum version limit of __`>3.8`__ to the `python_requires` section in the `setup.py` to match all the other MoSeq2 repositories.

## Breaking Changes
None

## Checklists
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
