### PR TITLE
chore: update links in download scripts

### DIFF
--- a/scripts/download_test_dataset.sh
+++ b/scripts/download_test_dataset.sh
@@ -1,2 +1,2 @@
-curl -L -o data.zip https://www.dropbox.com/sh/pv3p6i67zi6krxo/AACAsXyuDoq7IWe-ECN6UR7-a?dl=0 && unzip data.zip -d data
+curl -L -o data.zip https://www.dropbox.com/sh/54eut9x98l2kik0/AABZ4OxC2Mr7wNcD9Y7mCQwda?dl=0 && unzip data.zip -d data
 rm data.zip


### PR DESCRIPTION
## Issue being fixed or feature implemented
Update links to download test data since Ayman's dropbox links will no longer be available.