### PR TITLE
Add documentation installation option and fix default option to remove 'set -e' in kappa scan

### DIFF
--- a/docs/moseq2_model.train.rst
+++ b/docs/moseq2_model.train.rst
@@ -10,7 +10,7 @@ Train - Model Module
    :show-inheritance:
 
 Train - General Utilities Module
--------------------------------
+--------------------------------
 
 .. automodule:: moseq2_model.train.util
    :members:

--- a/moseq2_model/cli.py
+++ b/moseq2_model/cli.py
@@ -306,6 +306,7 @@ def apply_model(model_file, pc_file, dest_file, **config_data):
 )
 @click.option("--get-cmd", is_flag=True, help="Print scan command strings.")
 @click.option("--run-cmd", is_flag=True, help="Run scan command strings.")
+@click.option("--error-on-fail", is_flag=True, help="Exit script if any model fails to train.")
 @modeling_parameters
 def kappa_scan_fit_models(input_file, output_dir, **config_data):
     # Scan through the kappa hyperparameter to find the kappa that best matches the changepoint duration distribution.

--- a/moseq2_model/util.py
+++ b/moseq2_model/util.py
@@ -634,7 +634,8 @@ def create_command_strings(
 
     # Create and return the command string
     command_string = "\n".join(commands)
-    command_string = "set -e\n" + command_string
+    if config_data.get("error_on_fail", False):
+        command_string = "set -e\n" + command_string
     return command_string
 
 

--- a/setup.py
+++ b/setup.py
@@ -77,4 +77,11 @@ setup(
         "autoregressive @ git+https://github.com/dattalab/pyhsmm-autoregressive.git@master",
     ],
     entry_points={"console_scripts": ["moseq2-model = moseq2_model.cli:cli"]},
+    extras_require={
+        "docs": [
+            "sphinx",
+            "sphinx-click",
+            "sphinx-rtd-theme",
+        ],
+    },
 )


### PR DESCRIPTION
This pull request includes two commits. The first commit adds an installation option for documentation. The second commit fixes the default option to remove the 'set -e' command in the kappa scan. This ensures that the script will exit if any model fails to train, as specified by the new '--error-on-fail' flag.