### PR TITLE
Auto-Regularize AR Parameters to Constrain Numeric Instability

### DIFF
--- a/moseq2_model/train/util.py
+++ b/moseq2_model/train/util.py
@@ -201,6 +201,7 @@ def train_model(
     iter_lls, iter_holls = [], []
 
     for itr in tqdm(range(start, num_iter), **progress_kwargs, desc="Training ARHMM"):
+        # Resample states, and gracefully return in case of a keyboard interrupt.
         try:
             if model._obs_stats is not None:
                 regularize_for_stability(model.obs_distns, model._obs_stats)

--- a/moseq2_model/train/util.py
+++ b/moseq2_model/train/util.py
@@ -59,7 +59,12 @@ def minimum_regularization_coefficient(A, B, C):
         S = A - np.linalg.solve(C_reg, B.T).T.dot(B.T)
         min_eigenvalue_S = min(np.linalg.eigvalsh(S))
         min_eigenvalue_C = min(np.linalg.eigvalsh(C_reg))
-        min_eigenvalue_inv_C = min(np.linalg.eigvalsh(inv_psd(C_reg)))
+
+        # Can't calculate inverse of C if C is not positive definite
+        if min_eigenvalue_C > 0:
+            min_eigenvalue_inv_C = min(np.linalg.eigvalsh(inv_psd(C_reg)))
+        else:
+            min_eigenvalue_inv_C = 0
         
         if (min_eigenvalue_S > 0) and (min_eigenvalue_C > 0) and (min_eigenvalue_inv_C > 0):
             return {
@@ -109,7 +114,11 @@ def regularize_for_stability(obs_distns, obs_stats):
         S = A - np.linalg.solve(C, B.T).T.dot(B.T)
         min_eigenvalue_S = min(np.linalg.eigvalsh(S))
         min_eigenvalue_C = min(np.linalg.eigvalsh(C))
-        min_eigenvalue_inv_C = min(np.linalg.eigvalsh(inv_psd(C)))
+
+        if min_eigenvalue_C > 0:
+            min_eigenvalue_inv_C = min(np.linalg.eigvalsh(inv_psd(C)))
+        else:
+            min_eigenvalue_inv_C = 0
 
         if (min_eigenvalue_S > 0) and (min_eigenvalue_C > 0) and (min_eigenvalue_inv_C > 0):
             continue 

--- a/moseq2_model/train/util.py
+++ b/moseq2_model/train/util.py
@@ -10,38 +10,6 @@ from cytoolz import valmap, itemmap
 from collections import OrderedDict, defaultdict
 from moseq2_model.util import save_arhmm_checkpoint, get_loglikelihoods
 
-def residual_covariance(A, B, C):
-    """
-    Compute residual covariance matrix after linear regression.
-    
-    For a multivariate linear model Y = X * β + ε, computes the residual covariance
-    matrix using the formula A - B * C^(-1) * B^T.
-
-    This gives the covariance of residuals after fitting the optimal linear 
-    relationship between outputs and inputs.
-    
-    Parameters
-    ----------
-    A : ndarray, shape (n_outputs, n_outputs)
-        Total output covariance matrix. 
-    B : ndarray, shape (n_outputs, n_predictors) 
-        Cross-covariance between outputs and inputs.
-    C : ndarray, shape (n_predictors, n_predictors)
-        Input Gram matrix (design matrix covariance).
-        
-    Returns
-    -------
-    ndarray, shape (n_outputs, n_outputs)
-        Residual covariance matrix after linear regression.
-        
-    Notes
-    -----
-    Uses solve() instead of explicit matrix inversion for numerical stability.
-    Mathematically equivalent to the Schur complement of C in the block matrix
-    [[C, B^T], [B, A]].
-    """
-    return A - np.linalg.solve(C, B.T).T.dot(B.T)
-
 def minimum_regularization_coefficient(A, B, C):
     """
     Find minimum ridge regularization coefficient to ensure positive definite residual covariance.
@@ -70,8 +38,12 @@ def minimum_regularization_coefficient(A, B, C):
         Dictionary containing:
         - 'regularization' : float
             Minimum ridge regularization coefficient λ needed
-        - 'final_min_eigenvalue' : float
+        - 'final_min_eigenvalue_S' : float
             Smallest eigenvalue of regularized residual covariance matrix
+        - 'final_min_eigenvalue_C' : float
+            Smallest eigenvalue of regularized Gram matrix C
+        - 'final_min_eigenvalue_inv_C' : float
+            Smallest eigenvalue of inverse of regularized Gram matrix C
             
     Notes
     -----
@@ -84,7 +56,7 @@ def minimum_regularization_coefficient(A, B, C):
     regularization = initial_regularization_factor
     while True:
         C_reg = C + regularization * np.eye(C.shape[0])
-        S = residual_covariance(A, B, C_reg)
+        S = A - np.linalg.solve(C_reg, B.T).T.dot(B.T)
         min_eigenvalue_S = min(np.linalg.eigvalsh(S))
         min_eigenvalue_C = min(np.linalg.eigvalsh(C_reg))
         min_eigenvalue_inv_C = min(np.linalg.eigvalsh(inv_psd(C_reg)))
@@ -134,7 +106,7 @@ def regularize_for_stability(obs_distns, obs_stats):
         natparam = obs.natural_hypparam + statmat
         A, B, C, _ = natparam
 
-        S = residual_covariance(A, B, C)
+        S = A - np.linalg.solve(C, B.T).T.dot(B.T)
         min_eigenvalue_S = min(np.linalg.eigvalsh(S))
         min_eigenvalue_C = min(np.linalg.eigvalsh(C))
         min_eigenvalue_inv_C = min(np.linalg.eigvalsh(inv_psd(C)))

--- a/moseq2_model/train/util.py
+++ b/moseq2_model/train/util.py
@@ -3,6 +3,7 @@ ARHMM utility functions
 """
 
 import numpy as np
+from pybasicbayes.util.general import inv_psd
 from tqdm.auto import tqdm
 from functools import partial
 from cytoolz import valmap, itemmap
@@ -84,10 +85,17 @@ def minimum_regularization_coefficient(A, B, C):
     while True:
         C_reg = C + regularization * np.eye(C.shape[0])
         S = residual_covariance(A, B, C_reg)
-        min_eigenvalue = min(np.linalg.eigvalsh(S))
+        min_eigenvalue_S = min(np.linalg.eigvalsh(S))
+        min_eigenvalue_C = min(np.linalg.eigvalsh(C_reg))
+        min_eigenvalue_inv_C = min(np.linalg.eigvalsh(inv_psd(C_reg)))
         
-        if min_eigenvalue > 0:
-            return {'regularization': regularization, 'final_min_eigenvalue': min_eigenvalue}
+        if (min_eigenvalue_S > 0) and (min_eigenvalue_C > 0) and (min_eigenvalue_inv_C > 0):
+            return {
+                'regularization': regularization,
+                'final_min_eigenvalue_S': min_eigenvalue_S,
+                'final_min_eigenvalue_C': min_eigenvalue_C,
+                'final_min_eigenvalue_inv_C': min_eigenvalue_inv_C
+            }
             
         regularization *= 1.05
 
@@ -127,16 +135,22 @@ def regularize_for_stability(obs_distns, obs_stats):
         A, B, C, _ = natparam
 
         S = residual_covariance(A, B, C)
-        min_eigenvalue = min(np.linalg.eigvalsh(S))
+        min_eigenvalue_S = min(np.linalg.eigvalsh(S))
+        min_eigenvalue_C = min(np.linalg.eigvalsh(C))
+        min_eigenvalue_inv_C = min(np.linalg.eigvalsh(inv_psd(C)))
 
-        if min_eigenvalue > 0:
+        if (min_eigenvalue_S > 0) and (min_eigenvalue_C > 0) and (min_eigenvalue_inv_C > 0):
             continue 
 
         result = minimum_regularization_coefficient(A, B, C)
         regularization = result['regularization']
-        final_min_eigenvalue = result['final_min_eigenvalue']
+        final_min_eigenvalue_S = result['final_min_eigenvalue_S']
+        final_min_eigenvalue_C = result['final_min_eigenvalue_C']
+        final_min_eigenvalue_inv_C = result['final_min_eigenvalue_inv_C']
 
-        print(f'Regularized AR params for state {i}: {min_eigenvalue:.2e} → {final_min_eigenvalue:.2e} (ridge regression coeff = {regularization:.2e})')
+        print(f'Regularized S params for state {i}: {min_eigenvalue_S:.2e} → {final_min_eigenvalue_S:.2e} (ridge regression coeff = {regularization:.2e})')
+        print(f'Regularized C params for state {i}: {min_eigenvalue_C:.2e} → {final_min_eigenvalue_C:.2e}')
+        print(f'Regularized inv_C (K) params for state {i}: {min_eigenvalue_inv_C:.2e} → {final_min_eigenvalue_inv_C:.2e}')
         obs.natural_hypparam[2] = C + regularization * np.eye(C.shape[0])
 
 def train_model(

--- a/moseq2_model/train/util.py
+++ b/moseq2_model/train/util.py
@@ -201,10 +201,21 @@ def train_model(
     iter_lls, iter_holls = [], []
 
     for itr in tqdm(range(start, num_iter), **progress_kwargs, desc="Training ARHMM"):
-        # Check and regularize natural parameters before resampling
-        if model._obs_stats is not None:
-            regularize_for_stability(model.obs_distns, model._obs_stats)
-        model.resample_model(num_procs=ncpus)
+        try:
+            if model._obs_stats is not None:
+                regularize_for_stability(model.obs_distns, model._obs_stats)
+            model.resample_model(num_procs=ncpus)
+        except KeyboardInterrupt:
+            print("Training manually interrupted.")
+            print("Returning and saving current iteration of model. ")
+            return (
+                model,
+                model.log_likelihood(),
+                get_labels_from_model(model),
+                iter_lls,
+                iter_holls,
+                True,
+            )
 
         summ_stats = {
             "model": model,

--- a/moseq2_model/train/util.py
+++ b/moseq2_model/train/util.py
@@ -9,6 +9,135 @@ from cytoolz import valmap, itemmap
 from collections import OrderedDict, defaultdict
 from moseq2_model.util import save_arhmm_checkpoint, get_loglikelihoods
 
+def residual_covariance(A, B, C):
+    """
+    Compute residual covariance matrix after linear regression.
+    
+    For a multivariate linear model Y = X * β + ε, computes the residual covariance
+    matrix using the formula A - B * C^(-1) * B^T.
+
+    This gives the covariance of residuals after fitting the optimal linear 
+    relationship between outputs and inputs.
+    
+    Parameters
+    ----------
+    A : ndarray, shape (n_outputs, n_outputs)
+        Total output covariance matrix. 
+    B : ndarray, shape (n_outputs, n_predictors) 
+        Cross-covariance between outputs and inputs.
+    C : ndarray, shape (n_predictors, n_predictors)
+        Input Gram matrix (design matrix covariance).
+        
+    Returns
+    -------
+    ndarray, shape (n_outputs, n_outputs)
+        Residual covariance matrix after linear regression.
+        
+    Notes
+    -----
+    Uses solve() instead of explicit matrix inversion for numerical stability.
+    Mathematically equivalent to the Schur complement of C in the block matrix
+    [[C, B^T], [B, A]].
+    """
+    return A - np.linalg.solve(C, B.T).T.dot(B.T)
+
+def minimum_regularization_coefficient(A, B, C):
+    """
+    Find minimum ridge regularization coefficient to ensure positive definite residual covariance.
+    
+    For a multivariate linear model Y = X * β + ε, computes the minimum regularization 
+    needed for the design matrix Gram matrix C to make the residual covariance 
+    S = A - B * C^(-1) * B^T positive definite. Uses ridge regularization: C_reg = C + λ * I.
+    
+    Parameters
+    ----------
+    A : ndarray, shape (n_outputs, n_outputs)
+        Total output covariance matrix (Y^T Y). Represents total variance/covariance 
+        structure in the response variables.
+        
+    B : ndarray, shape (n_outputs, n_predictors)
+        Cross-covariance between outputs and inputs (Y^T X). Captures how response 
+        variables relate to predictor variables.
+        
+    C : ndarray, shape (n_predictors, n_predictors)
+        Design matrix Gram matrix (X^T X). Represents covariance structure of predictor 
+        variables. Can become ill-conditioned with multicollinear predictors.
+        
+    Returns
+    -------
+    dict
+        Dictionary containing:
+        - 'regularization' : float
+            Minimum ridge regularization coefficient λ needed
+        - 'final_min_eigenvalue' : float
+            Smallest eigenvalue of regularized residual covariance matrix
+            
+    Notes
+    -----
+    The residual covariance S represents unexplained variance after linear regression. 
+    Regularization prevents numerical instability when C is ill-conditioned due to 
+    multicollinearity among predictors or insufficient data relative to model complexity.
+    """
+    initial_regularization_factor = 1e-4
+    
+    regularization = initial_regularization_factor
+    while True:
+        C_reg = C + regularization * np.eye(C.shape[0])
+        S = residual_covariance(A, B, C_reg)
+        min_eigenvalue = min(np.linalg.eigvalsh(S))
+        
+        if min_eigenvalue > 0:
+            return {'regularization': regularization, 'final_min_eigenvalue': min_eigenvalue}
+            
+        regularization *= 1.05
+
+def regularize_for_stability(obs_distns, obs_stats):
+    """
+    Regularize natural parameters to ensure positive definite residual covariance matrices.
+    
+    Iterates through observation distributions and their sufficient statistics, checking 
+    whether the resulting residual covariance matrix would be positive definite. If not,
+    applies ridge regularization to the Gram matrix (C component) to ensure numerical 
+    stability during model resampling.
+    
+    This prevents crashes in downstream Bayesian inference when natural parameters
+    plus sufficient statistics lead to non-positive-definite covariance matrices.
+    
+    Parameters
+    ----------
+    obs_distns : list of AutoRegression objects
+        Observation distribution objects for each state in the HMM. Each contains
+        natural_hypparam attribute that will be modified in-place if regularization
+        is needed.
+    obs_stats : list of ndarray
+        Sufficient statistics for each state, typically computed from data assigned
+        to that state. Combined with natural_hypparam to form posterior parameters.
+        
+    Notes
+    -----
+    Modifies obs_distns[i].natural_hypparam[2] in-place by adding ridge regularization
+    λ * I to the Gram matrix component when the residual covariance matrix has 
+    non-positive eigenvalues.
+    
+    Prints regularization information for each state that requires adjustment, showing
+    the improvement in minimum eigenvalue and the regularization coefficient used.
+    """
+    for i, (obs, statmat) in enumerate(zip(obs_distns, obs_stats)):
+        natparam = obs.natural_hypparam + statmat
+        A, B, C, _ = natparam
+
+        S = residual_covariance(A, B, C)
+        min_eigenvalue = min(np.linalg.eigvalsh(S))
+
+        if min_eigenvalue > 0:
+            continue 
+
+        result = minimum_regularization_coefficient(A, B, C)
+        regularization = result['regularization']
+        final_min_eigenvalue = result['final_min_eigenvalue']
+
+        print(f'Regularized AR params for state {i}: {min_eigenvalue:.2e} → {final_min_eigenvalue:.2e} (ridge regression coeff = {regularization:.2e})')
+        obs.natural_hypparam[2] = C + regularization * np.eye(C.shape[0])
 
 def train_model(
     model,
@@ -58,20 +187,10 @@ def train_model(
     iter_lls, iter_holls = [], []
 
     for itr in tqdm(range(start, num_iter), **progress_kwargs, desc="Training ARHMM"):
-        # Resample states, and gracefully return in case of a keyboard interrupt
-        try:
-            model.resample_model(num_procs=ncpus)
-        except KeyboardInterrupt:
-            print("Training manually interrupted.")
-            print("Returning and saving current iteration of model. ")
-            return (
-                model,
-                model.log_likelihood(),
-                get_labels_from_model(model),
-                iter_lls,
-                iter_holls,
-                True,
-            )
+        # Check and regularize natural parameters before resampling
+        if model._obs_stats is not None:
+            regularize_for_stability(model.obs_distns, model._obs_stats)
+        model.resample_model(num_procs=ncpus)
 
         summ_stats = {
             "model": model,

--- a/moseq2_model/train/util.py
+++ b/moseq2_model/train/util.py
@@ -201,7 +201,7 @@ def train_model(
     iter_lls, iter_holls = [], []
 
     for itr in tqdm(range(start, num_iter), **progress_kwargs, desc="Training ARHMM"):
-        # Resample states, and gracefully return in case of a keyboard interrupt.
+        # Resample states, and gracefully return in case of a keyboard interrupt
         try:
             if model._obs_stats is not None:
                 regularize_for_stability(model.obs_distns, model._obs_stats)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
When there are long periods of little to no movement, the AR parameters start to become unstable and we can hit negative eigenvalues in covariance matrices, leading to crashes.


## What was done?
A check was put in the resample model loop to make sure all parameters from the last resample are valid (no negative eigenvalues) before attempting the next resample.


## How Has This Been Tested?
Ran the model at many kappas on a dataset known to cause this numeric instability.
