### PR TITLE
CI: add installed-package MoSeq2 regression tests

### DIFF
--- a/.github/workflows/moseq2-test.yml
+++ b/.github/workflows/moseq2-test.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Build the candidate wheel and run its affected MoSeq2 tests
-        uses: dattalab/moseq2-test@eb652cd8058a2fe34f7ea3c2d638aa7f6f2ebb47
+        uses: dattalab/moseq2-test@9e696dbbc3e36169366ec309656b87183524ff3d
         with:
           package: moseq2-model
           source: ${{ github.workspace }}

--- a/.github/workflows/moseq2-test.yml
+++ b/.github/workflows/moseq2-test.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Build the candidate wheel and run its affected MoSeq2 tests
-        uses: dattalab/moseq2-test@b23eb6c2cb84f4d37868b24abc8fb2b02f9d3ebe
+        uses: dattalab/moseq2-test@eb652cd8058a2fe34f7ea3c2d638aa7f6f2ebb47
         with:
           package: moseq2-model
           source: ${{ github.workspace }}

--- a/.github/workflows/moseq2-test.yml
+++ b/.github/workflows/moseq2-test.yml
@@ -1,0 +1,27 @@
+name: MoSeq2 installed-package tests
+
+on:
+  pull_request:
+  push:
+    branches: [release]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  moseq2-test:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out the pull-request source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Build the candidate wheel and run its affected MoSeq2 tests
+        uses: dattalab/moseq2-test@b23eb6c2cb84f4d37868b24abc8fb2b02f9d3ebe
+        with:
+          package: moseq2-model
+          source: ${{ github.workspace }}
+          tier: pull-request


### PR DESCRIPTION
## Summary

- add one informational GitHub-hosted workflow pinned to the final `moseq2-test` Action commit
- build this pull-request source into an installed candidate wheel
- run install-smoke, the 34-outcome `moseq2-model` historical contract, and the model-through-analysis pipeline slice

## Trust and scope

The job uses a disposable `ubuntu-24.04` runner with `contents: read`, no secrets, and no self-hosted access. Public fixtures are downloaded and checksum-verified before candidate execution; candidate build and tests then run network-disabled.

This PR changes only `.github/workflows/moseq2-test.yml`. It does not change runtime or build metadata, dependencies, scientific code, historical tests, or existing Travis configuration.

## Version identities and final validation

- central action: `dattalab/moseq2-test@9e696dbbc3e36169366ec309656b87183524ff3d`
- worker: `ghcr.io/dattalab/moseq2-test-legacy-worker@sha256:a500da25b5904a264be0d98223270189a7398aefaad97b78fa5a6d94fc20ddca`
- framework/schema/worker protocol: `0.1.0 / 1 / 1`
- successful final run: https://github.com/dattalab/moseq2-model/actions/runs/30856831404
- pilot dependency: dattalab/moseq2-extract#176

All three canonical profile records are accepted. This check remains informational; no required-check or merge action is part of this PR.
